### PR TITLE
Add initial Angular PWA package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "angular-pwa-app",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^20.0.0",
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/forms": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/platform-browser-dynamic": "^20.0.0",
+    "@angular/router": "^20.0.0",
+    "@angular/service-worker": "^20.0.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.2"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^20.0.0",
+    "@angular/cli": "^20.0.0",
+    "@angular/compiler-cli": "^20.0.0",
+    "@angular/pwa": "^20.0.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.1",
+    "karma": "~6.4.2",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.29",
+    "autoprefixer": "^10.4.16",
+    "typescript": "~5.5.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add base package.json with Angular 20 dependencies
- include service worker and Tailwind tooling for PWA setup

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e08fda2083308c688e15b67660c9